### PR TITLE
Make sure that the sass gulp run happens *before* the minification

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('sass', function() {
     .pipe(gulp.dest('./assets/css/'));
 });
 
-gulp.task('css', function() {
+gulp.task('css', ['sass'], function() {
   gulp.src('./assets/css/style.css')
     .pipe(cleanCSS())
     .pipe(rename({
@@ -29,6 +29,6 @@ gulp.task('serve', function() {
     }));
 });
 
-gulp.task('default', ['sass', 'css', 'serve'], function() {
-  gulp.watch(['./assets/sass/*.scss', './assets/sass/**/*.scss'], ['sass', 'css']);
+gulp.task('default', ['css', 'serve'], function() {
+  gulp.watch(['./assets/sass/*.scss', './assets/sass/**/*.scss'], ['css']);
 });


### PR DESCRIPTION
Made the `css` task dependent on the `sass` task so that the tasks always run in the same order.
